### PR TITLE
Change modify_rep_group to be more verbose

### DIFF
--- a/hacking/aws_config/testing_policies/ec2-policy.json
+++ b/hacking/aws_config/testing_policies/ec2-policy.json
@@ -23,6 +23,7 @@
                 "ec2:CreateVpc",
                 "ec2:DeleteKeyPair",
                 "ec2:DeleteNatGateway",
+                "ec2:DeleteSecurityGroup",
                 "ec2:DeleteSnapshot",
                 "ec2:DeleteSubnet",
                 "ec2:DeleteVpc",

--- a/hacking/aws_config/testing_policies/elasticache-policy.json
+++ b/hacking/aws_config/testing_policies/elasticache-policy.json
@@ -1,0 +1,26 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "ElasticachePermissions",
+            "Effect": "Allow",
+            "Action": [
+                "elasticache:CreateCacheCluster",
+                "elasticache:CreateReplicationGroup",
+                "elasticache:CreateSnapshot",
+                "elasticache:CreateCacheSubnetGroup",
+                "elasticache:DeleteCacheCluster",
+                "elasticache:DeleteReplicationGroup",
+                "elasticache:DeleteSnapshot",
+                "elasticache:DeleteCacheSubnetGroup",
+                "elasticache:DescribeCacheClusters",
+                "elasticache:DescribeReplicationGroups",
+                "elasticache:DescribeCacheSubnetGroups",
+                "elasticache:ModifyCacheCluster",
+                "elasticache:ModifyCacheSubnetGroup",
+                "elasticache:ModifyReplicationGroup"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/lib/ansible/modules/cloud/amazon/elasticache_replication_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_replication_group.py
@@ -1,0 +1,422 @@
+#!/usr/bin/python
+#
+# This is a free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This Ansible library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: elasticache_replication_group
+short_description: Manage AWS Elasticache replication groups
+description:
+    - Manage AWS Elasticache replication groups
+version_added: "2.1"
+author: Rob White (@wimnat)
+options:
+  name:
+    auto_minor_version_upgrade:
+      - "Whether to automatically perform minor engine upgrades."
+    required: false
+    default: false
+    id:
+      - "The replication group identifier."
+    required: true
+    default: null
+  description:
+    description:
+      - "A user-created description for the replication group."
+    required: true
+    default: null
+  primary_cluster_id:
+    description:
+      - "The identifier of the cache cluster that will serve as the primary for this replication group. This cache cluster must already exist and have a status of available."
+    required: false
+    default: null
+  failover_enabled:
+    description:
+      - "Specifies whether a read-only replica will be automaticaly promoted to read/write primary if the existing primary fails. If true, Multi-AZ is enabled for this replication group."
+      required: false
+      default: false
+  region:
+    description:
+     - "The AWS region to use. If not specified then the value of the EC2_REGION environment variable, if any, is used. See U(http://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region)."
+    required: false
+    default: null
+  num_of_cache_clusters:
+    description:
+      - "The number of cache clusters this replication group will have. If Multi-AZ is enabled (see failover_enabled option), this parameter must be at least 2."
+      required: false
+      default: null
+  preferred_cache_cluster_azs:
+    description:
+      - "A list of EC2 availability zones in which the replication group's cache clusters will be created."
+      required: false
+      default: null
+  cache_node_type:
+    description:
+      - "The compute and memory capacity of the nodes in the node group."
+      required: false
+      default: null
+  engine:
+    description:
+      - "The name of the cache engine to be used for the cache clusters in this replication group."
+      required: false
+      default: redis
+  engine_version:
+    description:
+      - "The version number of the cache engine to be used for the cache clusters in this replication group."
+      required: false
+      default: null
+  cache_parameter_group_name:
+    description:
+      - "The name of the parameter group to associate with this replication group. If this argument is omitted, the default cache parameter group for the specified engine is used."
+      required: false
+      default: null
+  cache_subnet_group_name:
+    description:
+      - "The name of the cache subnet group to be used for the replication group."
+      required: false
+      default: null
+  cache_security_group_names:
+    description:
+      - "A list of cache security group names to associate with this replication group."
+      required: false
+      default: null
+  security_group_ids:
+    description:
+      - "One or more Amazon VPC security groups associated with this replication group. Use this parameter only when you are creating a replication group in an Amazon Virtual Private Cloud (VPC)."
+      required: false
+      default: null
+  tags:
+    description:
+      - "A list of cost allocation tags to be added to this resource. A tag is a key-value pair. A tag key must be accompanied by a tag value."
+      required: false
+      default: null
+  snapshot_arn:
+    description:
+      - "An Amazon Resource Name (ARN) that uniquely identifies a Redis RDB snapshot file stored in Amazon S3. The snapshot file will be used to populate the node group. The Amazon S3 object name in the ARN cannot contain any commas. This parameter is only valid if the Engine parameter is redis."
+      required: false
+      default: null
+  snapshot_name:
+    description:
+      - "The name of a snapshot from which to restore data into the new node group. The snapshot status changes to restoring while the new node group is being created. This parameter is only valid if the Engine parameter is redis."
+      required: false
+      default: null
+  preferred_maintenance_window:
+    description:
+      - "Specifies the weekly time range during which maintenance on the cache cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). Example: sun:05:00-sun:09:00. The minimum maintenance window is a 60 minute period."
+      required: false
+      default: null
+  port:
+    description:
+      - "The port number on which each member of the replication group will accept connections."
+      required: false
+      default: null
+  notification_topic_arn:
+    description:
+      - "The Amazon Resource Name (ARN) of the Amazon Simple Notification Service (SNS) topic to which notifications will be sent. The Amazon SNS topic owner must be the same as the cache cluster owner."
+      required: false
+      default: null
+  state:
+    description:
+      - "Create or remove the Elasticache replication group"
+    required: false
+    default: null
+    choices: [ 'present', 'absent' ]
+  snapshot_retention_limit:
+    description:
+      - "The number of days for which ElastiCache will retain automatic snapshots before deleting them. For example, if you set snapshot_retention_limit to 5, then a snapshot that was taken today will be retained for 5 days before being deleted."
+    required: false
+    default: 0 (backups disabled)
+  snapshot_window:
+    description:
+      - "The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your node group. Example: 05:00-09:00. "
+      - "If you do not specify this parameter, then ElastiCache will automatically choose an appropriate time range."
+      - "This parameter is only valid if the Engine parameter is redis."
+    required: false
+    default: null
+  retain_primary_cluster:
+    description:
+      - "When removing a replication group, if set to true, all of the read replicas will be deleted, but the primary node will be retained."
+    required: false
+    default: null
+  final_snapshot_id:
+    description:
+      - "When removing a replication group, if set, the name of a final node group snapshot."
+    required: false
+    default: null
+  wait:
+    description: Wait for the replication group to be in state 'available' before returning
+    required: false
+    default: no
+    choices: [ "yes", "no" ]
+
+extends_documentation_fragment: aws
+'''
+
+EXAMPLES = '''
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+
+#
+
+'''
+
+import time
+
+try:
+    import boto
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+
+try:
+    import botocore
+    import boto3
+    HAS_BOTO3 = True
+except ImportError:
+    HAS_BOTO3 = False
+
+
+def check_for_rep_group(module, connection):
+
+    params = dict()
+
+    params['ReplicationGroupId'] = module.params.get('id')
+
+    try:
+        result = connection.describe_replication_groups(**params)
+    except botocore.exceptions.ClientError as e:
+        if e.response['Error']['Code'] == 'ReplicationGroupNotFoundFault':
+            return False
+        else:
+            module.fail_json(msg=e.message)
+
+    return result
+
+
+def create_rep_group(module, connection):
+
+    params = dict()
+
+    params['ReplicationGroupId'] = module.params.get('id')
+    params['ReplicationGroupDescription'] = module.params.get('description')
+    params['PrimaryClusterId'] = module.params.get('primary_cluster_id')
+    params['AutomaticFailoverEnabled'] = module.params.get('failover_enabled')
+    params['NumCacheClusters'] = module.params.get('num_of_cache_clusters')
+    params['PreferredCacheClusterAZs'] = module.params.get('preferred_cache_cluster_azs')
+    params['CacheNodeType'] = module.params.get('cache_node_type')
+    params['Engine'] = module.params.get('engine')
+    params['EngineVersion'] = module.params.get('engine_version')
+    params['CacheParameterGroupName'] = module.params.get('cache_parameter_group_name')
+    params['CacheSubnetGroupName'] = module.params.get('cache_subnet_group_name')
+    params['CacheSecurityGroupNames'] = module.params.get('cache_security_group_names')
+    params['SecurityGroupIds'] = module.params.get('security_group_ids')
+    # need to do stuff here
+    params['Tags'] = module.params.get('tags')
+    # need to do stuff here
+    params['SnapshotArns'] = module.params.get('snapshot_arn')
+    params['PreferredMaintenanceWindow'] = module.params.get('preferred_maintenance_window')
+    params['Port'] = module.params.get('port')
+    params['NotificationTopicArn'] = module.params.get('notification_topic_arn')
+    params['AutoMinorVersionUpgrade'] = module.params.get('auto_minor_version_upgrade')
+    params['SnapshotRetentionLimit'] = module.params.get('snapshot_retention_limit')
+    params['SnapshotWindow'] = module.params.get('snapshot_window')
+
+    # Remove any items with a value of None
+    for k,v in list(params.items()):
+        if v is None:
+            del params[k]
+
+    try:
+        response = connection.create_replication_group(**params)
+    except botocore.exceptions.ClientError as e:
+        module.fail_json(msg=e.message)
+
+    wait = module.params.get('wait')
+
+    if wait:
+        waiter = connection.get_waiter('replication_group_available')
+        waiter.wait(ReplicationGroupId=params['ReplicationGroupId'])
+        rep_group = connection.describe_replication_groups({'ReplicationGroupId': params['ReplicationGroupId']})
+        module.exit_json(changed=True, **rep_group['ReplicationGroups'][0])
+    else:
+        module.exit_json(changed=True, **response)
+
+
+def destroy_rep_group(module, connection):
+
+    params = dict()
+
+    params['ReplicationGroupId'] = module.params.get('id')
+    params['RetainPrimaryCluster'] = module.params.get('retain_primary_cluster')
+    params['FinalSnapshotIdentifier'] = module.params.get('final_snapshot_id')
+
+    # Remove any items with a value of None
+    for k,v in list(params.items()):
+        if v is None:
+            del params[k]
+
+    try:
+        result = connection.delete_replication_groups(**params)
+    except botocore.exceptions.ClientError as e:
+        module.fail_json(msg=e.message)
+
+    print result
+
+
+def modify_rep_group(module, connection, rep_group):
+
+    changed = False
+
+    params = dict()
+
+    params['ReplicationGroupId'] = module.params.get('id')
+    if params['ReplicationGroupId'] == rep_group['ReplicationGroups'][0]['ReplicationGroupId']:
+        del params['ReplicationGroupId']
+    params['ReplicationGroupDescription'] = module.params.get('description')
+    if params['ReplicationGroupDescription'] == rep_group['ReplicationGroups'][0]['ReplicationGroupDescription']:
+        del params['ReplicationGroupDescription']
+    params['PrimaryClusterId'] = module.params.get('primary_cluster_id')
+    if params['PrimaryClusterId'] == rep_group['ReplicationGroups'][0]['PrimaryClusterId']:
+        del params['PrimaryClusterId']
+    params['AutomaticFailoverEnabled'] = module.params.get('failover_enabled')
+    if params['AutomaticFailoverEnabled'] == rep_group['ReplicationGroups'][0]['AutomaticFailoverEnabled']:
+        del params['AutomaticFailoverEnabled']
+    params['NumCacheClusters'] = module.params.get('num_of_cache_clusters')
+    if params['NumCacheClusters'] == rep_group['ReplicationGroups'][0]['NumCacheClusters']:
+        del params['NumCacheClusters']
+    params['PreferredCacheClusterAZs'] = module.params.get('preferred_cache_cluster_azs')
+    if params['PreferredCacheClusterAZs'] == rep_group['ReplicationGroups'][0]['PreferredCacheClusterAZs']:
+        del params['PreferredCacheClusterAZs']
+    params['CacheNodeType'] = module.params.get('cache_node_type')
+    if params['CacheNodeType'] == rep_group['ReplicationGroups'][0]['CacheNodeType']:
+        del params['CacheNodeType']
+    params['Engine'] = module.params.get('engine')
+    if params['Engine'] == rep_group['ReplicationGroups'][0]['Engine']:
+        del params['Engine']
+    params['EngineVersion'] = module.params.get('engine_version')
+    if params['EngineVersion'] == rep_group['ReplicationGroups'][0]['EngineVersion']:
+        del params['EngineVersion']
+    params['CacheParameterGroupName'] = module.params.get('cache_parameter_group_name')
+    if params['CacheParameterGroupName'] == rep_group['ReplicationGroups'][0]['CacheParameterGroupName']:
+        del params['CacheParameterGroupName']
+    params['CacheSubnetGroupName'] = module.params.get('cache_subnet_group_name')
+    if params['CacheSubnetGroupName'] == rep_group['ReplicationGroups'][0]['CacheSubnetGroupName']:
+        del params['CacheSubnetGroupName']
+    params['CacheSecurityGroupNames'] = module.params.get('cache_security_group_names')
+    if params['CacheSecurityGroupNames'] == rep_group['ReplicationGroups'][0]['CacheSecurityGroupNames']:
+        del params['CacheSecurityGroupNames']
+    params['SecurityGroupIds'] = module.params.get('security_group_ids')
+    if params['SecurityGroupIds'] == rep_group['ReplicationGroups'][0]['SecurityGroupIds']:
+        del params['SecurityGroupIds']
+    # need to do stuff here
+    params['Tags'] = module.params.get('tags')
+    if params['Tags'] == rep_group['ReplicationGroups'][0]['Tags']:
+        del params['Tags']
+    # need to do stuff here
+    params['SnapshotArns'] = module.params.get('snapshot_arn')
+    if params['SnapshotArns'] == rep_group['ReplicationGroups'][0]['SnapshotArns']:
+        del params['SnapshotArns']
+    params['PreferredMaintenanceWindow'] = module.params.get('preferred_maintenance_window')
+    if params['PreferredMaintenanceWindow'] == rep_group['ReplicationGroups'][0]['PreferredMaintenanceWindow']:
+        del params['PreferredMaintenanceWindow']
+    params['Port'] = module.params.get('port')
+    if params['Port'] == rep_group['ReplicationGroups'][0]['Port']:
+        del params['Port']
+    params['NotificationTopicArn'] = module.params.get('notification_topic_arn')
+    if params['NotificationTopicArn'] == rep_group['ReplicationGroups'][0]['NotificationTopicArn']:
+        del params['NotificationTopicArn']
+    params['AutoMinorVersionUpgrade'] = module.params.get('auto_minor_version_upgrade')
+    if params['AutoMinorVersionUpgrade'] == rep_group['ReplicationGroups'][0]['AutoMinorVersionUpgrade']:
+        del params['AutoMinorVersionUpgrade']
+    params['SnapshotRetentionLimit'] = module.params.get('snapshot_retention_limit')
+    if params['SnapshotRetentionLimit'] == rep_group['ReplicationGroups'][0]['SnapshotRetentionLimit']:
+        del params['SnapshotRetentionLimit']
+    params['SnapshotWindow'] = module.params.get('snapshot_window')
+    if params['SnapshotWindow'] == rep_group['ReplicationGroups'][0]['SnapshotWindow']:
+        del params['SnapshotWindow']
+
+    #module.exit_json(replication_group=rep_group['ReplicationGroups'])
+    module.exit_json(changed=changed, **rep_group['ReplicationGroups'][0])
+
+
+def main():
+
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(
+        dict(
+            auto_minor_version_upgrade=dict(default=False, required=False, type='bool'),
+            id=dict(default=None, required=True, type='str'),
+            description=dict(default=None, required=True, type='str'),
+            primary_cluster_id=dict(default=None, required=False, type='str'),
+            failover_enabled=dict(default=False, required=False, type='bool'),
+            num_of_cache_clusters=dict(default=None, required=False, type='int'),
+            preferred_cache_cluster_azs=dict(default=None, required=False, type='list'),
+            cache_node_type=dict(default=None, required=False, type='str'),
+            engine=dict(default='redis', required=False, type='str', choices=['redis']),
+            engine_version=dict(default=None, required=False, type='str'),
+            cache_parameter_group_name=dict(default=None, required=False, type='str'),
+            cache_subnet_group_name=dict(default=None, required=False, type='str'),
+            cache_security_group_names=dict(default=None, required=False, type='list'),
+            security_group_ids=dict(default=None, required=False, type='list'),
+            tags=dict(default=None, required=False, type='dict'),
+            snapshot_arn=dict(default=None, required=False, type='str'),
+            snapshot_name=dict(default=None, required=False, type='str'),
+            preferred_maintenance_window=dict(default=None, required=False, type='str'),
+            port=dict(default=None, required=False, type='int'),
+            notification_topic_arn=dict(default=None, required=False, type='str'),
+            state=dict(default=None, choices=['present', 'absent']),
+            snapshot_retention_limit=dict(default=0, required=False, type='int'),
+            snapshot_window=dict(default=None, required=False, type='str'),
+            retain_primary_cluster=dict(default=False, required=False, type='bool'),
+            final_snapshot_id=dict(default=None, required=False, type='str'),
+            wait=dict(default=False, required=False, type='bool'),
+        )
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec, required_one_of=[['primary_cluster_id', 'num_of_cache_clusters']],)
+
+    if not HAS_BOTO:
+        module.fail_json(msg='boto required for this module')
+
+    if not HAS_BOTO3:
+        module.fail_json(msg='boto3 required for this module')
+
+    try:
+        region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
+        connection = boto3_conn(module, conn_type='client', resource='elasticache', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+    except boto.exception.NoAuthHandlerFound, e:
+        module.fail_json(msg=str(e))
+
+    state = module.params.get('state')
+
+    if state == "present":
+        rep_group = check_for_rep_group(module, connection)
+        if rep_group is False:
+            create_rep_group(module, connection)
+        else:
+            modify_rep_group(module, connection, rep_group)
+    elif state == "absent":
+        rep_group = check_for_rep_group(module, connection)
+        if rep_group is False:
+            module.exit_json(changed=False)
+        else:
+            destroy_rep_group(module, connection)
+
+
+
+# import module snippets
+from ansible.module_utils.basic import *
+from ansible.module_utils.ec2 import *
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/elasticache_replication_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_replication_group.py
@@ -383,7 +383,6 @@ def reboot_rep_group(module, connection, rep_group):
         try:
             connection.reboot_cache_cluster(CacheClusterId=node_group['CacheClusterId'],
                                             CacheNodeIdsToReboot=[node_group['CacheNodeId']])
-
             changed = True
             if module.params.get('wait'):
                 waiter = connection.get_waiter('cache_cluster_available')
@@ -458,7 +457,7 @@ def modify_rep_group(module, connection, rep_group):
             params['AutomaticFailoverEnabled'] = module.params['failover_enabled']
             changed = True
 
-    current_cache_cluster_count = len(rep_group['NodeGroups'][0]['NodeGroupMembers'])
+    current_cache_cluster_count = len(rep_group['MemberClusters'])
     while module.params['num_cache_clusters'] < current_cache_cluster_count:
         cluster_to_remove = [cc for cc in rep_group['NodeGroups'][0]['NodeGroupMembers']
                              if cc['CurrentRole'] != 'primary'][-1]

--- a/lib/ansible/modules/cloud/amazon/elasticache_replication_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_replication_group.py
@@ -1,17 +1,12 @@
 #!/usr/bin/python
 #
-# This is a free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# Copyright (c) 2017 Ansible Project
 #
-# This Ansible library is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
 
 DOCUMENTATION = '''
 ---
@@ -19,141 +14,115 @@ module: elasticache_replication_group
 short_description: Manage AWS Elasticache replication groups
 description:
     - Manage AWS Elasticache replication groups
-version_added: "2.1"
-author: Rob White (@wimnat)
+version_added: "2.5"
+author:
+  - Rob White (@wimnat)
+  - Will Thames (@willthames)
 options:
   name:
-    auto_minor_version_upgrade:
-      - "Whether to automatically perform minor engine upgrades."
-    required: false
-    default: false
-    id:
-      - "The replication group identifier."
+    description:
+      - The replication group identifier.
     required: true
-    default: null
   description:
     description:
-      - "A user-created description for the replication group."
-    required: true
-    default: null
+      - A user-created description for the replication group. Required when I(state) is C(present)
   primary_cluster_id:
     description:
-      - "The identifier of the cache cluster that will serve as the primary for this replication group. This cache cluster must already exist and have a status of available."
-    required: false
-    default: null
+      - The identifier of the cache cluster that will serve as the primary for this replication group.
+        This cache cluster must already exist and have a status of available.
   failover_enabled:
     description:
-      - "Specifies whether a read-only replica will be automaticaly promoted to read/write primary if the existing primary fails. If true, Multi-AZ is enabled for this replication group."
-      required: false
-      default: false
+      - Specifies whether a read-only replica will be automaticaly promoted to read/write primary
+        if the existing primary fails. If true, Multi-AZ is enabled for this replication group.
+    default: false
   region:
     description:
-     - "The AWS region to use. If not specified then the value of the EC2_REGION environment variable, if any, is used. See U(http://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region)."
-    required: false
-    default: null
-  num_of_cache_clusters:
+     - The AWS region to use. If not specified then the value of the EC2_REGION environment variable,
+       if any, is used. See U(http://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region).
+  num_cache_clusters:
     description:
-      - "The number of cache clusters this replication group will have. If Multi-AZ is enabled (see failover_enabled option), this parameter must be at least 2."
-      required: false
-      default: null
+      - The number of cache clusters this replication group will have. If Multi-AZ
+        is enabled (see failover_enabled option), this parameter must be at least 2.
+  apply_immediately:
+    description:
+      - Whether to apply major changes (engine version, node type) immediately or await a later reboot
+    default: False
+  auto_minor_version_upgrade:
+    description:
+      - Whether to automatically perform minor engine upgrades.
+    default: false
   preferred_cache_cluster_azs:
     description:
-      - "A list of EC2 availability zones in which the replication group's cache clusters will be created."
-      required: false
-      default: null
-  cache_node_type:
+      - A list of EC2 availability zones in which the replication group's cache clusters will be created.
+  node_type:
     description:
-      - "The compute and memory capacity of the nodes in the node group."
-      required: false
-      default: null
+      - The compute and memory capacity of the nodes in the node group.
   engine:
     description:
-      - "The name of the cache engine to be used for the cache clusters in this replication group."
-      required: false
-      default: redis
-  engine_version:
+      - The name of the cache engine to be used for the cache clusters in this replication group.
+    default: redis
+  cache_engine_version:
     description:
-      - "The version number of the cache engine to be used for the cache clusters in this replication group."
-      required: false
-      default: null
-  cache_parameter_group_name:
+      - The version number of the cache engine to be used for the cache clusters in this replication group.
+  cache_parameter_group:
     description:
-      - "The name of the parameter group to associate with this replication group. If this argument is omitted, the default cache parameter group for the specified engine is used."
-      required: false
-      default: null
+      - The name of the parameter group to associate with this replication group.
+        If this argument is omitted, the default cache parameter group for the specified engine is used.
   cache_subnet_group_name:
     description:
-      - "The name of the cache subnet group to be used for the replication group."
-      required: false
-      default: null
-  cache_security_group_names:
+      - The name of the cache subnet group to be used for the replication group.
+  cache_security_groups:
     description:
-      - "A list of cache security group names to associate with this replication group."
-      required: false
-      default: null
+      - A list of cache security group names to associate with this replication group.
   security_group_ids:
     description:
-      - "One or more Amazon VPC security groups associated with this replication group. Use this parameter only when you are creating a replication group in an Amazon Virtual Private Cloud (VPC)."
-      required: false
-      default: null
-  tags:
-    description:
-      - "A list of cost allocation tags to be added to this resource. A tag is a key-value pair. A tag key must be accompanied by a tag value."
-      required: false
-      default: null
+      - One or more Amazon VPC security groups associated with this replication group.
+        Use this parameter only when you are creating a replication group in an Amazon Virtual Private Cloud (VPC).
   snapshot_arn:
     description:
-      - "An Amazon Resource Name (ARN) that uniquely identifies a Redis RDB snapshot file stored in Amazon S3. The snapshot file will be used to populate the node group. The Amazon S3 object name in the ARN cannot contain any commas. This parameter is only valid if the Engine parameter is redis."
-      required: false
-      default: null
+      - An Amazon Resource Name (ARN) that uniquely identifies a Redis RDB snapshot
+        file stored in Amazon S3. The snapshot file will be used to populate the node group.
+        The Amazon S3 object name in the ARN cannot contain any commas. This parameter is
+        only valid if the I(engine) parameter is C(redis).
   snapshot_name:
     description:
-      - "The name of a snapshot from which to restore data into the new node group. The snapshot status changes to restoring while the new node group is being created. This parameter is only valid if the Engine parameter is redis."
-      required: false
-      default: null
+      - The name of a snapshot from which to restore data into the new node group.
+        The snapshot status changes to restoring while the new node group is being created.
+        This parameter is only valid if the I(engine) parameter is C(redis).
   preferred_maintenance_window:
     description:
-      - "Specifies the weekly time range during which maintenance on the cache cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). Example: sun:05:00-sun:09:00. The minimum maintenance window is a 60 minute period."
-      required: false
-      default: null
-  port:
+      - Specifies the weekly time range during which maintenance on the cache cluster
+        is performed. It is specified as a range in the format C(ddd:hh24:mi-ddd:hh24:mi) (24H Clock UTC).
+        e.g. C(sun:05:00-sun:09:00). The minimum maintenance window is a 60 minute period.
+  cache_port:
     description:
-      - "The port number on which each member of the replication group will accept connections."
-      required: false
-      default: null
+      - The port number on which each member of the replication group will accept connections.
   notification_topic_arn:
     description:
-      - "The Amazon Resource Name (ARN) of the Amazon Simple Notification Service (SNS) topic to which notifications will be sent. The Amazon SNS topic owner must be the same as the cache cluster owner."
-      required: false
-      default: null
+      - The Amazon Resource Name (ARN) of the Amazon Simple Notification Service (SNS) topic
+        to which notifications will be sent. The Amazon SNS topic owner must be the same as the cache cluster owner.
   state:
     description:
-      - "Create or remove the Elasticache replication group"
-    required: false
-    default: null
-    choices: [ 'present', 'absent' ]
+      - Create or remove the Elasticache replication group
+    required: true
+    choices: [ 'present', 'absent', 'rebooted' ]
   snapshot_retention_limit:
     description:
-      - "The number of days for which ElastiCache will retain automatic snapshots before deleting them. For example, if you set snapshot_retention_limit to 5, then a snapshot that was taken today will be retained for 5 days before being deleted."
-    required: false
+      - The number of days for which ElastiCache will retain automatic snapshots before deleting them.
+        For example, if you set I(snapshot_retention_limit) to 5, then a snapshot that was taken today
+        will be retained for 5 days before being deleted.
     default: 0 (backups disabled)
   snapshot_window:
     description:
-      - "The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your node group. Example: 05:00-09:00. "
-      - "If you do not specify this parameter, then ElastiCache will automatically choose an appropriate time range."
-      - "This parameter is only valid if the Engine parameter is redis."
-    required: false
-    default: null
+      - The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your node group e.g. C(05:00-09:00).
+        If you do not specify this parameter, then ElastiCache will automatically choose an appropriate time range.
+        This parameter is only valid if the I(engine) parameter is C(redis).
   retain_primary_cluster:
     description:
-      - "When removing a replication group, if set to true, all of the read replicas will be deleted, but the primary node will be retained."
-    required: false
-    default: null
+      - When removing a replication group, if set to true, all of the read replicas will be deleted, but the primary node will be retained.
   final_snapshot_id:
     description:
-      - "When removing a replication group, if set, the name of a final node group snapshot."
-    required: false
-    default: null
+      - When removing a replication group, if set, the name of a final node group snapshot.
   wait:
     description: Wait for the replication group to be in state 'available' before returning
     required: false
@@ -166,111 +135,264 @@ extends_documentation_fragment: aws
 EXAMPLES = '''
 # Note: These examples do not set authentication details, see the AWS Guide for details.
 
-#
+- name: create a 2 node, multi AZ replication group
+  elasticache_replication_group:
+    name: my-replica-group
+    num_cache_clusters: 2
+    failover_enabled: yes
+    description: Ansible Test Elasticache Replication Group
+    node_type: cache.t2.micro
+    security_group_ids:
+      - "{{ ec2_group_create.group_id }}"
+    cache_subnet_group_name: "{{ resource_prefix}}elasticache-subnet-group"
+    wait: yes
 
+- name: increase the replication group size to 4 nodes
+  elasticache_replication_group:
+    name: my-replica-group
+    num_cache_clusters: 4
+    failover_enabled: yes
+    description: Ansible Test Elasticache Replication Group
+    node_type: cache.t2.micro
+    security_group_ids:
+      - "{{ ec2_group_create.group_id }}"
+    cache_subnet_group_name: "{{ resource_prefix}}elasticache-subnet-group"
+    wait: yes
 '''
 
-import time
+RETURN = '''
+automatic_failover:
+  description: Whether the Replication Group fails over automatically
+  returned: always
+  type: string
+  sample: disabled
+cache_node_type:
+  description: Instance type of the cache nodes
+  returned: always
+  type: string
+  sample: cache.t2.micro
+cluster_enabled:
+  description: Whether the cluster is of type enabled or disabled
+  returned: always
+  type: bool
+  sample: false
+description:
+  description: Description of the Replication Group
+  returned: always
+  type: string
+  sample: Ansible Test Elasticache Replication Group
+member_clusters:
+  description: Cache clusters belonging to the replication group
+  returned: always
+  type: list
+  sample:
+  - cache-cluster-001
+  - cache-cluster-002
+node_groups:
+  description: Node groups belonging to the cluster
+  returned: always
+  type: complex
+  contains:
+    node_group_id:
+      description: ID of the node group
+      returned: always
+      type: string
+      sample: '0001'
+    node_group_members:
+      description: List of members of the node group
+      returned: always
+      type: complex
+      contains:
+        cache_cluster_id:
+          description: ID of the cache cluster
+          returned: always
+          type: string
+          sample: ansible-testing-erg-001
+        cache_node_id:
+          description: ID of the cache node
+          returned: always
+          type: string
+          sample: '0001'
+        current_role:
+          description: Whether the node is primary or replica
+          returned: always
+          type: string
+          sample: primary
+        preferred_availability_zone:
+          description: Availability Zone preferred by the cache node
+          returned: always
+          type: string
+          sample: us-east-2a
+        read_endpoint:
+          description: Endpoint used to read from this node
+          returned: always
+          type: complex
+          contains:
+            address:
+              description: Address of this endpoint
+              returned: always
+              type: string
+              sample: ansible-testing-erg-001.qh5gss.0001.use2.cache.amazonaws.com
+            port:
+              description: Port for the endpoint of the current node
+              returned: always
+              type: int
+              sample: 6379
+    primary_endpoint:
+      description: Endpoint for the Primary node in the replication group
+      returned: always
+      type: complex
+      contains:
+        address:
+          description: Address of the replication group endpoint
+          returned: always
+          type: string
+          sample: ansible-testing-erg.qh5gss.ng.0001.use2.cache.amazonaws.com
+        port:
+          description: Port of the replication group endpoint
+          returned: always
+          type: int
+          sample: 6379
+    status:
+      description: Status of the node group
+      returned: always
+      type: string
+      sample: available
+pending_modified_values:
+  description: Values that are awaiting a reboot to complete modification
+  returned: always
+  type: complex
+  contains: {}
+replication_group_id:
+  description: ID of the Replication Group
+  returned: always
+  type: string
+  sample: ansible-testing-erg
+status:
+  description: Status of the replication group
+  returned: always
+  type: string
+  sample: available
+'''
 
-try:
-    import boto
-    HAS_BOTO = True
-except ImportError:
-    HAS_BOTO = False
+from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, ec2_argument_spec
+from ansible.module_utils.ec2 import HAS_BOTO3, camel_dict_to_snake_dict
+from ansible.module_utils.aws.core import AnsibleAWSModule
+
 
 try:
     import botocore
-    import boto3
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # caught by imported HAS_BOTO3
 
 
 def check_for_rep_group(module, connection):
 
     params = dict()
 
-    params['ReplicationGroupId'] = module.params.get('id')
+    params['ReplicationGroupId'] = module.params['name']
 
     try:
         result = connection.describe_replication_groups(**params)
-    except botocore.exceptions.ClientError as e:
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         if e.response['Error']['Code'] == 'ReplicationGroupNotFoundFault':
-            return False
+            return None
         else:
-            module.fail_json(msg=e.message)
+            module.fail_json_aws(e, msg="Couldn't search for replication group %s" % module.params['name'])
 
-    return result
+    return result['ReplicationGroups'][0]
 
 
 def create_rep_group(module, connection):
 
     params = dict()
 
-    params['ReplicationGroupId'] = module.params.get('id')
+    params['ReplicationGroupId'] = module.params.get('name')
     params['ReplicationGroupDescription'] = module.params.get('description')
     params['PrimaryClusterId'] = module.params.get('primary_cluster_id')
     params['AutomaticFailoverEnabled'] = module.params.get('failover_enabled')
-    params['NumCacheClusters'] = module.params.get('num_of_cache_clusters')
+    params['NumCacheClusters'] = module.params.get('num_cache_clusters')
     params['PreferredCacheClusterAZs'] = module.params.get('preferred_cache_cluster_azs')
-    params['CacheNodeType'] = module.params.get('cache_node_type')
+    params['CacheNodeType'] = module.params.get('node_type')
     params['Engine'] = module.params.get('engine')
-    params['EngineVersion'] = module.params.get('engine_version')
-    params['CacheParameterGroupName'] = module.params.get('cache_parameter_group_name')
+    params['EngineVersion'] = module.params.get('cache_engine_version')
+    params['CacheParameterGroupName'] = module.params.get('cache_parameter_group')
     params['CacheSubnetGroupName'] = module.params.get('cache_subnet_group_name')
-    params['CacheSecurityGroupNames'] = module.params.get('cache_security_group_names')
+    params['CacheSecurityGroupNames'] = module.params.get('cache_security_groups')
     params['SecurityGroupIds'] = module.params.get('security_group_ids')
-    # need to do stuff here
-    params['Tags'] = module.params.get('tags')
     # need to do stuff here
     params['SnapshotArns'] = module.params.get('snapshot_arn')
     params['PreferredMaintenanceWindow'] = module.params.get('preferred_maintenance_window')
-    params['Port'] = module.params.get('port')
+    params['Port'] = module.params.get('cache_port')
     params['NotificationTopicArn'] = module.params.get('notification_topic_arn')
     params['AutoMinorVersionUpgrade'] = module.params.get('auto_minor_version_upgrade')
     params['SnapshotRetentionLimit'] = module.params.get('snapshot_retention_limit')
     params['SnapshotWindow'] = module.params.get('snapshot_window')
 
     # Remove any items with a value of None
-    for k,v in list(params.items()):
+    for k, v in list(params.items()):
         if v is None:
             del params[k]
 
     try:
-        response = connection.create_replication_group(**params)
-    except botocore.exceptions.ClientError as e:
-        module.fail_json(msg=e.message)
+        connection.create_replication_group(**params)
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        msg = "Couldn't create replication group"
+        if e.response['Error']['Code'] == 'InvalidParameterCombination':
+            msg = msg + (". This might be because of unsupported settings for T1/T2 instances. See: "
+                         "http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific"
+                         " for more details")
+        module.fail_json_aws(e, msg=msg)
 
-    wait = module.params.get('wait')
-
-    if wait:
+    if module.params.get('wait'):
         waiter = connection.get_waiter('replication_group_available')
         waiter.wait(ReplicationGroupId=params['ReplicationGroupId'])
-        rep_group = connection.describe_replication_groups({'ReplicationGroupId': params['ReplicationGroupId']})
-        module.exit_json(changed=True, **rep_group['ReplicationGroups'][0])
-    else:
-        module.exit_json(changed=True, **response)
+
+    rep_group = check_for_rep_group(module, connection)
+    module.exit_json(changed=True, **camel_dict_to_snake_dict(rep_group))
 
 
 def destroy_rep_group(module, connection):
 
     params = dict()
 
-    params['ReplicationGroupId'] = module.params.get('id')
+    params['ReplicationGroupId'] = module.params.get('name')
     params['RetainPrimaryCluster'] = module.params.get('retain_primary_cluster')
     params['FinalSnapshotIdentifier'] = module.params.get('final_snapshot_id')
 
     # Remove any items with a value of None
-    for k,v in list(params.items()):
+    for k, v in list(params.items()):
         if v is None:
             del params[k]
 
     try:
-        result = connection.delete_replication_groups(**params)
-    except botocore.exceptions.ClientError as e:
-        module.fail_json(msg=e.message)
+        connection.delete_replication_group(**params)
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Couldn't delete replication group")
 
-    print result
+    if module.params.get('wait'):
+        waiter = connection.get_waiter('replication_group_deleted')
+        waiter.wait(ReplicationGroupId=params['ReplicationGroupId'])
+        module.exit_json(changed=True)
+    else:
+        module.exit_json(changed=True)
+
+
+def reboot_rep_group(module, connection, rep_group):
+    for node_group in rep_group['NodeGroups'][0]['NodeGroupMembers']:
+        try:
+            connection.reboot_cache_cluster(CacheClusterId=node_group['CacheClusterId'],
+                                            CacheNodeIdsToReboot=[node_group['CacheNodeId']])
+
+            changed = True
+            if module.params.get('wait'):
+                waiter = connection.get_waiter('cache_cluster_available')
+                waiter.wait(CacheClusterId=node_group['CacheClusterId'])
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, "Couldn't reboot cache cluster %s" % node_group['CacheClusterId'])
+
+    result = check_for_rep_group(module, connection)
+    module.exit_json(changed=changed, **camel_dict_to_snake_dict(result))
 
 
 def modify_rep_group(module, connection, rep_group):
@@ -278,145 +400,187 @@ def modify_rep_group(module, connection, rep_group):
     changed = False
 
     params = dict()
+    warnings = list()
 
-    params['ReplicationGroupId'] = module.params.get('id')
-    if params['ReplicationGroupId'] == rep_group['ReplicationGroups'][0]['ReplicationGroupId']:
-        del params['ReplicationGroupId']
-    params['ReplicationGroupDescription'] = module.params.get('description')
-    if params['ReplicationGroupDescription'] == rep_group['ReplicationGroups'][0]['ReplicationGroupDescription']:
-        del params['ReplicationGroupDescription']
-    params['PrimaryClusterId'] = module.params.get('primary_cluster_id')
-    if params['PrimaryClusterId'] == rep_group['ReplicationGroups'][0]['PrimaryClusterId']:
-        del params['PrimaryClusterId']
-    params['AutomaticFailoverEnabled'] = module.params.get('failover_enabled')
-    if params['AutomaticFailoverEnabled'] == rep_group['ReplicationGroups'][0]['AutomaticFailoverEnabled']:
-        del params['AutomaticFailoverEnabled']
-    params['NumCacheClusters'] = module.params.get('num_of_cache_clusters')
-    if params['NumCacheClusters'] == rep_group['ReplicationGroups'][0]['NumCacheClusters']:
-        del params['NumCacheClusters']
-    params['PreferredCacheClusterAZs'] = module.params.get('preferred_cache_cluster_azs')
-    if params['PreferredCacheClusterAZs'] == rep_group['ReplicationGroups'][0]['PreferredCacheClusterAZs']:
-        del params['PreferredCacheClusterAZs']
-    params['CacheNodeType'] = module.params.get('cache_node_type')
-    if params['CacheNodeType'] == rep_group['ReplicationGroups'][0]['CacheNodeType']:
-        del params['CacheNodeType']
-    params['Engine'] = module.params.get('engine')
-    if params['Engine'] == rep_group['ReplicationGroups'][0]['Engine']:
-        del params['Engine']
-    params['EngineVersion'] = module.params.get('engine_version')
-    if params['EngineVersion'] == rep_group['ReplicationGroups'][0]['EngineVersion']:
-        del params['EngineVersion']
-    params['CacheParameterGroupName'] = module.params.get('cache_parameter_group_name')
-    if params['CacheParameterGroupName'] == rep_group['ReplicationGroups'][0]['CacheParameterGroupName']:
-        del params['CacheParameterGroupName']
-    params['CacheSubnetGroupName'] = module.params.get('cache_subnet_group_name')
-    if params['CacheSubnetGroupName'] == rep_group['ReplicationGroups'][0]['CacheSubnetGroupName']:
-        del params['CacheSubnetGroupName']
-    params['CacheSecurityGroupNames'] = module.params.get('cache_security_group_names')
-    if params['CacheSecurityGroupNames'] == rep_group['ReplicationGroups'][0]['CacheSecurityGroupNames']:
-        del params['CacheSecurityGroupNames']
-    params['SecurityGroupIds'] = module.params.get('security_group_ids')
-    if params['SecurityGroupIds'] == rep_group['ReplicationGroups'][0]['SecurityGroupIds']:
-        del params['SecurityGroupIds']
-    # need to do stuff here
-    params['Tags'] = module.params.get('tags')
-    if params['Tags'] == rep_group['ReplicationGroups'][0]['Tags']:
-        del params['Tags']
-    # need to do stuff here
-    params['SnapshotArns'] = module.params.get('snapshot_arn')
-    if params['SnapshotArns'] == rep_group['ReplicationGroups'][0]['SnapshotArns']:
-        del params['SnapshotArns']
-    params['PreferredMaintenanceWindow'] = module.params.get('preferred_maintenance_window')
-    if params['PreferredMaintenanceWindow'] == rep_group['ReplicationGroups'][0]['PreferredMaintenanceWindow']:
-        del params['PreferredMaintenanceWindow']
-    params['Port'] = module.params.get('port')
-    if params['Port'] == rep_group['ReplicationGroups'][0]['Port']:
-        del params['Port']
-    params['NotificationTopicArn'] = module.params.get('notification_topic_arn')
-    if params['NotificationTopicArn'] == rep_group['ReplicationGroups'][0]['NotificationTopicArn']:
-        del params['NotificationTopicArn']
-    params['AutoMinorVersionUpgrade'] = module.params.get('auto_minor_version_upgrade')
-    if params['AutoMinorVersionUpgrade'] == rep_group['ReplicationGroups'][0]['AutoMinorVersionUpgrade']:
-        del params['AutoMinorVersionUpgrade']
-    params['SnapshotRetentionLimit'] = module.params.get('snapshot_retention_limit')
-    if params['SnapshotRetentionLimit'] == rep_group['ReplicationGroups'][0]['SnapshotRetentionLimit']:
-        del params['SnapshotRetentionLimit']
-    params['SnapshotWindow'] = module.params.get('snapshot_window')
-    if params['SnapshotWindow'] == rep_group['ReplicationGroups'][0]['SnapshotWindow']:
-        del params['SnapshotWindow']
+    # The output keys of describe_replication_groups are different
+    # to the input keys of modify_replication_group
+    rep_group['ReplicationGroupDescription'] = rep_group['Description']
 
-    #module.exit_json(replication_group=rep_group['ReplicationGroups'])
-    module.exit_json(changed=changed, **rep_group['ReplicationGroups'][0])
+    rep_group_params = {
+        'description': 'ReplicationGroupDescription',
+        'primary_cluster_id': 'PrimaryClusterId',
+        'node_type': 'CacheNodeType',
+    }
+    cache_cluster_params = {
+        'cache_engine_version': 'EngineVersion',
+        'cache_parameter_group': 'CacheParameterGroupName',
+        'cache_subnet_group_name': 'CacheSubnetGroupName',
+        'cache_security_groups': 'CacheSecurityGroupNames',
+        'preferred_maintenance_window': 'PreferredMaintenanceWindow',
+        'notification_topic_arn': 'NotificationTopicArn',
+        'auto_minor_version_upgrade': 'AutoMinorVersionUpgrade',
+        'snapshot_retention_limit': 'SnapshotRetentionLimit',
+        'snapshot_window': 'SnapshotWindow',
+    }
+
+    cache_cluster_id = rep_group['MemberClusters'][0]
+    try:
+        cache_clusters = connection.describe_cache_clusters(CacheClusterId=cache_cluster_id)['CacheClusters']
+        cache_cluster = cache_clusters[0]
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        if e.response['Error']['Code'] == 'CacheClusterNotFound':
+            cache_cluster = dict()
+        else:
+            module.fail_json_aws(e, msg="Couldn't describe cache cluster")
+
+    for k, v in rep_group_params.items():
+        if module.params.get(k) is not None and rep_group[v] != module.params.get(k):
+            params[v] = module.params.get[k]
+
+    for k, v in cache_cluster_params.items():
+        if module.params.get(k) is not None:
+            if v in cache_cluster:
+                if cache_cluster.get(v) != module.params.get(k):
+                    params[v] = module.params.get(k)
+            else:
+                warnings.append("Cannot determine current cluster value for parameter "
+                                "%s. Blindly setting it" % k)
+                params[v] = module.params.get(k)
+
+    # data structure of returned security groups from describe_cache_clusters is
+    # different to that expected by modify_replication_group
+    if set(module.params['security_group_ids']) != set([sg['SecurityGroupId'] for sg in cache_cluster['SecurityGroups']]):
+        params['SecurityGroupIds'] = module.params['security_group_ids']
+
+    if module.params['failover_enabled'] is not None:
+        if (module.params['failover_enabled'] and rep_group['AutomaticFailover'] in ['disabled', 'disabling'] or
+                not module.params['failover_enabled'] and rep_group['AutomaticFailover'] in ['enabled', 'enabling']):
+            params['AutomaticFailoverEnabled'] = module.params['failover_enabled']
+            changed = True
+
+    current_cache_cluster_count = len(rep_group['NodeGroups'][0]['NodeGroupMembers'])
+    while module.params['num_cache_clusters'] < current_cache_cluster_count:
+        cluster_to_remove = [cc for cc in rep_group['NodeGroups'][0]['NodeGroupMembers']
+                             if cc['CurrentRole'] != 'primary'][-1]
+        try:
+            connection.delete_cache_cluster(CacheClusterId=cluster_to_remove['CacheClusterId'])
+            current_cache_cluster_count -= 1
+            changed = True
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, "Couldn't remove cache cluster %s" % cluster_to_remove['CacheClusterId'])
+
+    new_node_id = max([int(cc['CacheNodeId']) for cc in rep_group['NodeGroups'][0]['NodeGroupMembers']]) + 1
+    while module.params['num_cache_clusters'] > current_cache_cluster_count:
+        try:
+            # Cache Cluster Ids must be less than 20 letters and not contain two consecutive hyphens
+            # The replace is needed when the 16th character of the replication group happens to be a hyphen
+            new_cache_cluster_id = ("%s-%03d" % (rep_group['ReplicationGroupId'][:16], new_node_id)).replace('--', '-')
+            connection.create_cache_cluster(CacheClusterId=new_cache_cluster_id,
+                                            ReplicationGroupId=rep_group['ReplicationGroupId'])
+            new_node_id += 1
+            current_cache_cluster_count += 1
+            changed = True
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, "Couldn't add new cache cluster %s" % new_cache_cluster_id)
+        if module.params.get('wait'):
+            waiter = connection.get_waiter('cache_cluster_available')
+            waiter.wait(CacheClusterId=new_cache_cluster_id)
+
+    # FIXME: Handle both security group Ids and Names for SGs
+
+    if params:
+        params['ReplicationGroupId'] = module.params.get('name')
+        params['ApplyImmediately'] = module.params.get('apply_immediately')
+
+        try:
+            connection.modify_replication_group(**params)
+            changed = True
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            msg = "Couldn't modify replication group"
+            if e.response['Error']['Code'] == 'InvalidParameterCombination':
+                msg = msg + (". This might be because of unsupported settings for T1/T2 instances. See: "
+                             "http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific"
+                             " for more details")
+            module.fail_json_aws(e, msg=msg)
+
+    result = check_for_rep_group(module, connection)
+    module.exit_json(changed=changed, warnings=warnings, **camel_dict_to_snake_dict(result))
 
 
 def main():
-
     argument_spec = ec2_argument_spec()
     argument_spec.update(
         dict(
-            auto_minor_version_upgrade=dict(default=False, required=False, type='bool'),
-            id=dict(default=None, required=True, type='str'),
-            description=dict(default=None, required=True, type='str'),
-            primary_cluster_id=dict(default=None, required=False, type='str'),
-            failover_enabled=dict(default=False, required=False, type='bool'),
-            num_of_cache_clusters=dict(default=None, required=False, type='int'),
-            preferred_cache_cluster_azs=dict(default=None, required=False, type='list'),
-            cache_node_type=dict(default=None, required=False, type='str'),
-            engine=dict(default='redis', required=False, type='str', choices=['redis']),
-            engine_version=dict(default=None, required=False, type='str'),
-            cache_parameter_group_name=dict(default=None, required=False, type='str'),
-            cache_subnet_group_name=dict(default=None, required=False, type='str'),
-            cache_security_group_names=dict(default=None, required=False, type='list'),
-            security_group_ids=dict(default=None, required=False, type='list'),
-            tags=dict(default=None, required=False, type='dict'),
-            snapshot_arn=dict(default=None, required=False, type='str'),
-            snapshot_name=dict(default=None, required=False, type='str'),
-            preferred_maintenance_window=dict(default=None, required=False, type='str'),
-            port=dict(default=None, required=False, type='int'),
-            notification_topic_arn=dict(default=None, required=False, type='str'),
-            state=dict(default=None, choices=['present', 'absent']),
-            snapshot_retention_limit=dict(default=0, required=False, type='int'),
-            snapshot_window=dict(default=None, required=False, type='str'),
-            retain_primary_cluster=dict(default=False, required=False, type='bool'),
-            final_snapshot_id=dict(default=None, required=False, type='str'),
-            wait=dict(default=False, required=False, type='bool'),
+            auto_minor_version_upgrade=dict(default=False, type='bool'),
+            name=dict(required=True),
+            description=dict(),
+            primary_cluster_id=dict(),
+            failover_enabled=dict(default=False, type='bool'),
+            apply_immediately=dict(default=False, type='bool'),
+            num_cache_clusters=dict(type='int'),
+            preferred_cache_cluster_azs=dict(type='list'),
+            node_type=dict(),
+            engine=dict(default='redis', choices=['redis']),
+            cache_engine_version=dict(),
+            cache_parameter_group=dict(),
+            cache_subnet_group_name=dict(),
+            cache_security_groups=dict(type='list'),
+            security_group_ids=dict(type='list'),
+            snapshot_arn=dict(),
+            snapshot_name=dict(),
+            preferred_maintenance_window=dict(),
+            cache_port=dict(type='int'),
+            notification_topic_arn=dict(),
+            state=dict(required=True, choices=['present', 'absent', 'rebooted']),
+            snapshot_retention_limit=dict(),
+            snapshot_window=dict(),
+            retain_primary_cluster=dict(default=False, type='bool'),
+            final_snapshot_id=dict(),
+            wait=dict(default=False, type='bool'),
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec, required_one_of=[['primary_cluster_id', 'num_of_cache_clusters']],)
-
-    if not HAS_BOTO:
-        module.fail_json(msg='boto required for this module')
+    module = AnsibleAWSModule(argument_spec=argument_spec,
+                              required_one_of=[['primary_cluster_id', 'num_cache_clusters']],
+                              required_if=[['state', 'present', ['description', 'node_type']]])
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 required for this module')
 
+    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
+    if not region:
+        module.fail_json(msg="Region must be specified for this module")
     try:
-        region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-        connection = boto3_conn(module, conn_type='client', resource='elasticache', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-    except boto.exception.NoAuthHandlerFound, e:
-        module.fail_json(msg=str(e))
+        connection = boto3_conn(module, conn_type='client', resource='elasticache',
+                                region=region, endpoint=ec2_url, **aws_connect_kwargs)
+    except botocore.exceptions.BotoCoreError as e:
+        module.fail_json_aws(e, msg="Couldn't connect to AWS")
 
     state = module.params.get('state')
 
+    if module.params["num_cache_clusters"]:
+        if module.params["failover_enabled"] and module.params["num_cache_clusters"] == 1:
+            module.fail_json("Failover enabled requires at least two nodes")
+
     if state == "present":
         rep_group = check_for_rep_group(module, connection)
-        if rep_group is False:
+        if rep_group is None:
             create_rep_group(module, connection)
         else:
             modify_rep_group(module, connection, rep_group)
     elif state == "absent":
         rep_group = check_for_rep_group(module, connection)
-        if rep_group is False:
+        if rep_group is None:
             module.exit_json(changed=False)
         else:
             destroy_rep_group(module, connection)
+    elif state == "rebooted":
+        rep_group = check_for_rep_group(module, connection)
+        if rep_group:
+            reboot_rep_group(module, connection)
+        else:
+            module.fail_json(msg="Replication Group %s does not exist to reboot" % module.params['name'])
 
-
-
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
 
 if __name__ == '__main__':
     main()

--- a/test/integration/targets/elasticache_replication_group/aliases
+++ b/test/integration/targets/elasticache_replication_group/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+posix/ci/cloud/group1/aws

--- a/test/integration/targets/elasticache_replication_group/defaults/main.yml
+++ b/test/integration/targets/elasticache_replication_group/defaults/main.yml
@@ -1,0 +1,3 @@
+# max of 20 chars for elasticache_replication_group_id, not much to play with
+# also, just in case any double hyphens get added (also not allowed), make them single hyphens
+#elasticache_replication_group_id: "{{ (resource_prefix|regex_replace('ansible-test(ing)?', 'test') + '-erg')|replace('--', '-') }}"

--- a/test/integration/targets/elasticache_replication_group/meta/main.yml
+++ b/test/integration/targets/elasticache_replication_group/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - prepare_tests
+  - setup_ec2

--- a/test/integration/targets/elasticache_replication_group/tasks/main.yml
+++ b/test/integration/targets/elasticache_replication_group/tasks/main.yml
@@ -1,0 +1,289 @@
+- block:
+    - name: create a VPC
+      ec2_vpc_net:
+        name: "{{ resource_prefix }}vpc"
+        state: present
+        cidr_block: "10.231.10.0/24"
+        region: "{{ ec2_region }}"
+        aws_access_key: "{{ aws_access_key|default(omit) }}"
+        aws_secret_key: "{{ aws_secret_key|default(omit) }}"
+        security_token: "{{ security_token|default(omit) }}"
+        profile: "{{ profile|default(omit) }}"
+      register: ec2_vpc_net_create
+
+    - name: Create security group
+      ec2_group:
+        name: "{{ resource_prefix }}elasticache-sg"
+        state: present
+        description: Ansible Test Elasticache SG
+        rules:
+          - ports: 1234
+            cidr: "10.231.10.0/24"
+        region: "{{ ec2_region }}"
+        vpc_id: "{{ ec2_vpc_net_create.vpc.id }}"
+        aws_access_key: "{{ aws_access_key|default(omit) }}"
+        aws_secret_key: "{{ aws_secret_key|default(omit) }}"
+        security_token: "{{ security_token|default(omit) }}"
+        profile: "{{ profile|default(omit) }}"
+      register: ec2_group_create
+
+    - name: Create subnet
+      ec2_vpc_subnet:
+        state: present
+        cidr: "10.231.10.0/28"
+        az: "{{ ec2_region }}a"
+        vpc_id: "{{ ec2_vpc_net_create.vpc.id }}"
+        region: "{{ ec2_region }}"
+        aws_access_key: "{{ aws_access_key|default(omit) }}"
+        aws_secret_key: "{{ aws_secret_key|default(omit) }}"
+        security_token: "{{ security_token|default(omit) }}"
+        profile: "{{ profile|default(omit) }}"
+      register: ec2_vpc_subnet_create
+
+    - name: Create elasticache subnet group
+      elasticache_subnet_group:
+        name: "{{ resource_prefix}}elasticache-subnet-group"
+        state: present
+        description: Ansible Test Elasticache Subnet Group
+        subnets:
+          - "{{ ec2_vpc_subnet_create.subnet.id }}"
+        region: "{{ ec2_region }}"
+        aws_access_key: "{{ aws_access_key|default(omit) }}"
+        aws_secret_key: "{{ aws_secret_key|default(omit) }}"
+        security_token: "{{ security_token|default(omit) }}"
+        profile: "{{ profile|default(omit) }}"
+      register: elasticache_subnet_group_create
+
+    - name: Create elasticache_replication group
+      elasticache_replication_group:
+        name: "{{ elasticache_replication_group_id }}"
+        num_cache_clusters: 1
+        description: Ansible Test Elasticache Replication Group
+        node_type: cache.t2.micro
+        security_group_ids:
+          - "{{ ec2_group_create.group_id }}"
+        cache_subnet_group_name: "{{ resource_prefix}}elasticache-subnet-group"
+        state: present
+        region: "{{ ec2_region }}"
+        aws_access_key: "{{ aws_access_key|default(omit) }}"
+        aws_secret_key: "{{ aws_secret_key|default(omit) }}"
+        security_token: "{{ security_token|default(omit) }}"
+        profile: "{{ profile|default(omit) }}"
+        wait: yes
+      register: erg_create
+
+    - name: test elasticache replication group creation
+      assert:
+        that:
+          - erg_create.changed
+
+    - name: Do nothing to elasticache_replication group
+      elasticache_replication_group:
+        name: "{{ elasticache_replication_group_id }}"
+        num_cache_clusters: 1
+        description: Ansible Test Elasticache Replication Group
+        node_type: cache.t2.micro
+        security_group_ids:
+          - "{{ ec2_group_create.group_id }}"
+        cache_subnet_group_name: "{{ resource_prefix}}elasticache-subnet-group"
+        state: present
+        region: "{{ ec2_region }}"
+        aws_access_key: "{{ aws_access_key|default(omit) }}"
+        aws_secret_key: "{{ aws_secret_key|default(omit) }}"
+        security_token: "{{ security_token|default(omit) }}"
+        profile: "{{ profile|default(omit) }}"
+      register: erg_no_update
+
+    - name: test elasticache replication group idempotency
+      assert:
+        that:
+          - not erg_no_update.changed
+
+    - name: Increase elasticache_replication group size
+      elasticache_replication_group:
+        name: "{{ elasticache_replication_group_id }}"
+        num_cache_clusters: 2
+        description: Ansible Test Elasticache Replication Group
+        node_type: cache.t2.micro
+        security_group_ids:
+          - "{{ ec2_group_create.group_id }}"
+        cache_subnet_group_name: "{{ resource_prefix}}elasticache-subnet-group"
+        state: present
+        region: "{{ ec2_region }}"
+        aws_access_key: "{{ aws_access_key|default(omit) }}"
+        aws_secret_key: "{{ aws_secret_key|default(omit) }}"
+        security_token: "{{ security_token|default(omit) }}"
+        profile: "{{ profile|default(omit) }}"
+      register: erg_increase_size
+
+    - name: check that replication group size has increased
+      assert:
+        that:
+          - erg_increase_size.changed
+          - erg_increase_size.member_clusters|length == 2
+
+    # FIXME: need a massive wait here until replication to the second node is complete
+
+    - name: increase node size without apply_immediately
+      elasticache_replication_group:
+        name: "{{ elasticache_replication_group_id }}"
+        num_cache_clusters: 2
+        description: Ansible Test Elasticache Replication Group
+        node_type: cache.t2.small
+        security_group_ids:
+          - "{{ ec2_group_create.group_id }}"
+        cache_subnet_group_name: "{{ resource_prefix}}elasticache-subnet-group"
+        state: present
+        region: "{{ ec2_region }}"
+        aws_access_key: "{{ aws_access_key|default(omit) }}"
+        aws_secret_key: "{{ aws_secret_key|default(omit) }}"
+        security_token: "{{ security_token|default(omit) }}"
+        profile: "{{ profile|default(omit) }}"
+      register: erg_enable_failover
+
+    - name: check that cache_node_type is awaiting modification
+      assert:
+        that:
+          - erg_increase_size.changed
+          - "erg_increase_size.cache_node_type == 'cache.t2.micro'"
+          - "'cache_node_type' in erg_increase_node_size.pending_modification"
+
+    - name: reboot replication group
+      elasticache_replication_group:
+        name: "{{ elasticache_replication_group_id }}"
+        state: rebooted
+        wait: yes
+        region: "{{ ec2_region }}"
+        aws_access_key: "{{ aws_access_key|default(omit) }}"
+        aws_secret_key: "{{ aws_secret_key|default(omit) }}"
+        security_token: "{{ security_token|default(omit) }}"
+        profile: "{{ profile|default(omit) }}"
+      register: erg_reboot
+
+    - name: check that cache_node_type is now correct
+      assert:
+        that:
+          - erg_reboot.changed
+          - "erg_reboot.cache_node_type == 'cache.t2.small'"
+          - "'cache_node_type' not in erg_reboot.pending_modification"
+
+    - name: decrease node size again with apply_immediately
+      elasticache_replication_group:
+        name: "{{ elasticache_replication_group_id }}"
+        num_cache_clusters: 2
+        description: Ansible Test Elasticache Replication Group
+        node_type: cache.t2.micro
+        apply_immediately: yes
+        security_group_ids:
+          - "{{ ec2_group_create.group_id }}"
+        cache_subnet_group_name: "{{ resource_prefix}}elasticache-subnet-group"
+        state: present
+        region: "{{ ec2_region }}"
+        aws_access_key: "{{ aws_access_key|default(omit) }}"
+        aws_secret_key: "{{ aws_secret_key|default(omit) }}"
+        security_token: "{{ security_token|default(omit) }}"
+        profile: "{{ profile|default(omit) }}"
+      register: erg_immediate_node_increase
+
+    - name: check that cache_node_type is immediately applied
+      assert:
+        that:
+          - erg_immediate_node_increase.changed
+          - "erg_immediate_node_increase.cache_node_type == 'cache.t2.small'"
+          - "'cache_node_type' not in erg_immediate_node_increase.pending_modification"
+
+    - name: Turn on automatic failover
+      elasticache_replication_group:
+        name: "{{ elasticache_replication_group_id }}"
+        num_cache_clusters: 2
+        description: Ansible Test Elasticache Replication Group
+        node_type: cache.t2.micro
+        failover_enabled: yes
+        security_group_ids:
+          - "{{ ec2_group_create.group_id }}"
+        cache_subnet_group_name: "{{ resource_prefix}}elasticache-subnet-group"
+        state: present
+        region: "{{ ec2_region }}"
+        aws_access_key: "{{ aws_access_key|default(omit) }}"
+        aws_secret_key: "{{ aws_secret_key|default(omit) }}"
+        security_token: "{{ security_token|default(omit) }}"
+        profile: "{{ profile|default(omit) }}"
+      register: erg_enable_failover
+
+    - name: check that failover is enabled
+      assert:
+        that:
+          - erg_increase_size.changed
+          - erg_increase_size.automatic_failover
+
+
+  ### TEARDOWN STARTS HERE
+
+# blanking out always until tests stable again
+
+  always:
+    - name: Announce teardown start
+      debug:
+        msg: "***** TESTING COMPLETE. TEARDOWN STARTING *****"
+
+    - name: Destroy elasticache replication group
+      elasticache_replication_group:
+        name: "{{ elasticache_replication_group_id }}"
+        state: absent
+        region: "{{ ec2_region }}"
+        num_cache_clusters: 1
+        wait: yes
+        aws_access_key: "{{ aws_access_key|default(omit) }}"
+        aws_secret_key: "{{ aws_secret_key|default(omit) }}"
+        security_token: "{{ security_token|default(omit) }}"
+        profile: "{{ profile|default(omit) }}"
+      ignore_errors: yes
+
+    - name: Destroy security group
+      ec2_group:
+        name: "{{ resource_prefix }}elasticache-sg"
+        state: absent
+        region: "{{ ec2_region }}"
+        aws_access_key: "{{ aws_access_key|default(omit) }}"
+        aws_secret_key: "{{ aws_secret_key|default(omit) }}"
+        security_token: "{{ security_token|default(omit) }}"
+        profile: "{{ profile|default(omit) }}"
+      ignore_errors: yes
+
+    - name: Destroy elasticache subnet group
+      elasticache_subnet_group:
+        name: "{{ resource_prefix}}elasticache-subnet-group"
+        state: absent
+        region: "{{ ec2_region }}"
+        aws_access_key: "{{ aws_access_key|default(omit) }}"
+        aws_secret_key: "{{ aws_secret_key|default(omit) }}"
+        security_token: "{{ security_token|default(omit) }}"
+        profile: "{{ profile|default(omit) }}"
+      ignore_errors: yes
+      when: ec2_vpc_subnet_create is defined and not ec2_vpc_subnet_create.failed
+
+    - name: Destroy subnet
+      ec2_vpc_subnet:
+        state: absent
+        cidr: "10.231.10.0/28"
+        az: "{{ ec2_region }}a"
+        region: "{{ ec2_region }}"
+        vpc_id: "{{ ec2_vpc_net_create.vpc.id }}"
+        aws_access_key: "{{ aws_access_key|default(omit) }}"
+        aws_secret_key: "{{ aws_secret_key|default(omit) }}"
+        security_token: "{{ security_token|default(omit) }}"
+        profile: "{{ profile|default(omit) }}"
+      ignore_errors: yes
+      when: ec2_vpc_net_create is defined and not ec2_vpc_net_create.failed
+
+    - name: Destroy VPC
+      ec2_vpc_net:
+        name: "{{ resource_prefix }}vpc"
+        state: absent
+        cidr_block: "10.231.10.0/24"
+        region: "{{ ec2_region }}"
+        aws_access_key: "{{ aws_access_key|default(omit) }}"
+        aws_secret_key: "{{ aws_secret_key|default(omit) }}"
+        security_token: "{{ security_token|default(omit) }}"
+        profile: "{{ profile|default(omit) }}"
+      ignore_errors: yes


### PR DESCRIPTION
There seemed a little confusion in what was a rep group parameter and what was a cluster parameter.

I removed the dicts and loops and just wrote out each parameter which i think makes the code more understandable.

I also use the primary cluster for all comparisons rather than just the first one.

I also wrote a little todo next to the `new_node_id` variable definition because it didn't work in its current form but i couldn't really see why.  I thought you might want to take a second look.  As a quick fix i just added + 2 to the end instead of + 1